### PR TITLE
Accepted hosts starts with match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.iml
 target
 src/test/java/io/*
+.classpath
+.project
+.settings

--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ At least one must match to let the request pass, if none is set this validation 
 Note that a request without a principal will lead to a HTTP 401 whereas a request with a principal but not the right role will issue a HTTP 403.
 
 The host validation will use the JAX-RS `UriInfo#getRequestUri`.
-It relies on the system property `geronimo.metrics.jaxrs.acceptedHosts` and it takes a comma separated list of roles.
+It relies on the system property `geronimo.metrics.jaxrs.acceptedHosts` and it takes a comma separated list of hosts.
 At least one must match to let the request pass, if none is set this validation is ignored.
 The `<local>` value is an alias for `127.x.y.z` or `1::x` IP or `localhost`.
 

--- a/README.adoc
+++ b/README.adoc
@@ -44,6 +44,7 @@ Note that a request without a principal will lead to a HTTP 401 whereas a reques
 The host validation will use the JAX-RS `UriInfo#getRequestUri`.
 It relies on the system property `geronimo.metrics.jaxrs.acceptedHosts` and it takes a comma separated list of hosts.
 At least one must match to let the request pass, if none is set this validation is ignored.
+If the host value ends with a dot, the match is a start with match and not an exact match.
 The `<local>` value is an alias for `127.x.y.z` or `1::x` IP or `localhost`.
 
 Configuration example:
@@ -51,7 +52,7 @@ Configuration example:
 [source]
 ----
 -Dgeronimo.metrics.jaxrs.acceptedRoles=ops \
--Dgeronimo.metrics.jaxrs.acceptedHosts=my.remote.host
+-Dgeronimo.metrics.jaxrs.acceptedHosts=my.remote.host,10.0.0.
 ----
 
 IMPORTANT: the default is `geronimo.metrics.jaxrs.acceptedHosts=<local>` but you can disable the endpoints using `geronimo.metrics.jaxrs.activated=false`.

--- a/geronimo-metrics-common/src/main/java/org/apache/geronimo/microprofile/metrics/common/jaxrs/SecurityValidator.java
+++ b/geronimo-metrics-common/src/main/java/org/apache/geronimo/microprofile/metrics/common/jaxrs/SecurityValidator.java
@@ -43,13 +43,16 @@ public class SecurityValidator {
     private List<String> acceptedRoles;
 
     public void init() {
+        acceptedRoles = config("geronimo.metrics.jaxrs.acceptedRoles", identity()).orElse(null);
         acceptedHosts = config("geronimo.metrics.jaxrs.acceptedHosts", value -> {
             if ("<local>".equals(value)) {
                 return LOCAL_MATCHER;
             }
-            return (Predicate<String>) value::equals;
+            return Optional.ofNullable(value)
+                    .filter(v -> v.endsWith("."))
+                    .map(v -> ((Predicate<String>) p -> p.startsWith(v)))
+                    .orElse((Predicate<String>) value::equals);
         }).orElse(singletonList(LOCAL_MATCHER));
-        acceptedRoles = config("geronimo.metrics.jaxrs.acceptedRoles", identity()).orElse(null);
     }
 
     public void checkSecurity(final SecurityContext securityContext, final UriInfo uriInfo) {
@@ -85,4 +88,5 @@ public class SecurityValidator {
     protected String config(final String key) {
         return System.getProperty(key);
     }
+
 }

--- a/geronimo-metrics-common/src/main/java/org/apache/geronimo/microprofile/metrics/common/jaxrs/SecurityValidator.java
+++ b/geronimo-metrics-common/src/main/java/org/apache/geronimo/microprofile/metrics/common/jaxrs/SecurityValidator.java
@@ -88,5 +88,4 @@ public class SecurityValidator {
     protected String config(final String key) {
         return System.getProperty(key);
     }
-
 }

--- a/geronimo-metrics-common/src/test/java/org/apache/geronimo/microprofile/metrics/common/jaxrs/SecurityValidatorTest.java
+++ b/geronimo-metrics-common/src/test/java/org/apache/geronimo/microprofile/metrics/common/jaxrs/SecurityValidatorTest.java
@@ -27,8 +27,6 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import com.sun.org.apache.regexp.internal.RE;
-
 import org.junit.Test;
 
 public class SecurityValidatorTest {
@@ -96,6 +94,7 @@ public class SecurityValidatorTest {
         }
     };
     private static final UriInfo REMOTE = uri("http://geronimo.somewhere");
+    private static final UriInfo REMOTE_WITH_DOT = uri("http://10.0.0.0");
     private static final UriInfo LOCALHOST = uri("http://localhost");
 
     @Test
@@ -103,6 +102,20 @@ public class SecurityValidatorTest {
         new SecurityValidator() {{
             init();
         }}.checkSecurity(ANONYMOUS, LOCALHOST);
+    }
+
+    @Test
+    public void remoteWithDotValid() {
+        new SecurityValidator() {
+            {
+                init();
+            }
+
+            @Override
+            protected String config(final String key) {
+                return key.endsWith("acceptedHosts") ? "10." : null;
+            }
+        }.checkSecurity(ANONYMOUS, REMOTE_WITH_DOT);
     }
 
     @Test(expected = WebApplicationException.class)
@@ -166,6 +179,34 @@ public class SecurityValidatorTest {
                 return key.endsWith("acceptedRoles") ? "admin" : "geronimo.somewhere";
             }
         }.checkSecurity(ADMIN, REMOTE);
+    }
+
+    @Test
+    public void roleAndHostThatEndsWithDotValid() {
+        new SecurityValidator() {
+            {
+                init();
+            }
+
+            @Override
+            protected String config(final String key) {
+                return key.endsWith("acceptedRoles") ? "admin" : key.endsWith("acceptedHosts") ? "10." : null;
+            }
+        }.checkSecurity(ADMIN, REMOTE_WITH_DOT);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void roleAnonymousAndHostThatEndsWithDotValid() {
+        new SecurityValidator() {
+            {
+                init();
+            }
+
+            @Override
+            protected String config(final String key) {
+                return key.endsWith("acceptedRoles") ? "admin" : key.endsWith("acceptedHosts") ? "10." : null;
+            }
+        }.checkSecurity(LOGGED_NO_ROLE, REMOTE_WITH_DOT);
     }
 
     private static UriInfo uri(final String request) {


### PR DESCRIPTION
Hi,
I need to run my meecrowave microservice in a GCE k8s cluster, and I want to expose the metrics endpoint to prometheus-operator.
The GET requests come from a IP's range, and with the standard acceptedHosts configuration I can't use a fixed list of IP.
@rmannibucau  can you do a review of my pull request?